### PR TITLE
try updating qmk version

### DIFF
--- a/.github/workflows/build_cocot38mini.yml
+++ b/.github/workflows/build_cocot38mini.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       pull-requests: write # required for thollander/actions-comment-pull-request@v2
     env:
-      QMK_VERSION: '0.25.10'
+      QMK_VERSION: '0.25.17'
       PERSONAL_EMAIL: ${{ secrets.PERSONAL_EMAIL }}
       PERSONAL_EMAIL_DEV: ${{ secrets.PERSONAL_EMAIL_DEV }}
       WORK_EMAIL: ${{ secrets.WORK_EMAIL }}


### PR DESCRIPTION
一度GitHub actionsでビルドしたファームウェアをcocot38miniに入れると、その後ファームウェアが更新できなくなる問題の調査
（cocot38miniのビルドガイドで提供されているファームウェアを入れ直すと、治る）